### PR TITLE
feat: upgrade Node.js version to 22 across workflows and documentation

### DIFF
--- a/.github/workflows/firebase-hosting-channel.yml
+++ b/.github/workflows/firebase-hosting-channel.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       
       - name: Set environment variables
         run: |

--- a/.github/workflows/firebase-hosting-master.yml
+++ b/.github/workflows/firebase-hosting-master.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Set environment variables
         run: |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Os requerimentos para execução local do projeto são simples.
 
 `$ node --version && npm --version`
 
-_Para referência foram no desenvolvimento NodeJS v18 e NPM v9_
+_Para referência foram no desenvolvimento NodeJS v22 e NPM v9_
 
 Instale as **Dependências** do projeto com:
 `$ npm install`

--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -66,7 +66,7 @@ You need to have **[NodeJS](https://nodejs.org/)** and **[NPM](https://www.npmjs
 
 `$ node --version && npm --version`
 
-_For reference, NodeJS v18 and NPM v9 were used in development._
+_For reference, NodeJS v22 and NPM v9 were used in development._
 
 Install project **dependencies** with:
 `$ npm install`

--- a/firebase.json
+++ b/firebase.json
@@ -29,7 +29,7 @@
   },
   "functions": {
     "source": ".",
-    "runtime": "nodejs18",
+    "runtime": "nodejs22",
     "ignore": [
       "firebase.json",
       "firebase-debug.log",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/react-modal": "^3.13.1",
         "firebase": "^9.6.3",
         "firebase-admin": "^11.0.1",
-        "firebase-frameworks": "^0.10.6",
+        "firebase-frameworks": "^0.11.6",
         "firebase-functions": "^4.5.0",
         "graphql": "^16.2.0",
         "next": "^14.0.3",
@@ -43,7 +43,7 @@
         "typescript": "4.5.4"
       },
       "engines": {
-        "node": "18"
+        "node": "22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4308,9 +4308,10 @@
       }
     },
     "node_modules/firebase-frameworks": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.10.6.tgz",
-      "integrity": "sha512-GA3DBEUn5os34WOx5MRZttIJbRUk1gQIQH4nc6s6xillGle0tXKlGRyT97lnxpqrE52ueh7j2V2NonBpc5V38Q==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.11.6.tgz",
+      "integrity": "sha512-JpHvKE3rY6uQDAef4W2tnPzL25VABn/L43ZPp2D+4/Z6GHkFAblzsQXQ7piMB/pb2stQ/yTmGMlZe6HQPdfS3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@hapi/accept": "^6.0.1",
         "cookie": "^0.5.0",
@@ -4318,12 +4319,12 @@
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0 || ^22.0.0"
       },
       "peerDependencies": {
-        "firebase": "^9.0.0 || ^10.0.0",
-        "firebase-admin": "^11.0.1",
-        "sharp": "^0.32.1"
+        "firebase": "^9.9.0 || ^10.0.0 || ^11.0.0",
+        "firebase-admin": "^11.0.1 || ^12.0.0",
+        "sharp": "^0.32 || ^0.33"
       },
       "peerDependenciesMeta": {
         "firebase": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "update-do": "npx npm-check -u"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "babel": {
     "presets": [
@@ -28,7 +28,7 @@
     "@types/react-modal": "^3.13.1",
     "firebase": "^9.6.3",
     "firebase-admin": "^11.0.1",
-    "firebase-frameworks": "^0.10.6",
+    "firebase-frameworks": "^0.11.6",
     "firebase-functions": "^4.5.0",
     "graphql": "^16.2.0",
     "next": "^14.0.3",


### PR DESCRIPTION
This pull request updates the project's Node.js version from 18 to 22 across various configurations and documentation, along with a minor dependency upgrade for `firebase-frameworks`. These changes ensure compatibility with the latest Node.js features and runtime improvements.

### Node.js Version Updates:

* `.github/workflows/firebase-hosting-channel.yml` & `.github/workflows/firebase-hosting-master.yml`: Updated the Node.js version used in GitHub Actions workflows from `18` to `22`. [[1]](diffhunk://#diff-d1f432bfa3baeece64d612cf802ff898081a5c06085f3d4b3ae8cf049a9401daL19-R19) [[2]](diffhunk://#diff-d7d51bb2918444fdbe6c21b13561e5d391653cf451ee41ff34335e3396f691f1L18-R18)
* [`firebase.json`](diffhunk://#diff-3f7c92e2669f851959cda8776100cf4e921faefe7dff0061c0e21f7d2ac65122L32-R32): Changed the Firebase Functions runtime from `nodejs18` to `nodejs22`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Updated the `engines.node` field from `18` to `22` to specify the required Node.js version for the project.

### Documentation Updates:

* `README.md` & `docs/README-en.md`: Updated references to the Node.js version used in development from `v18` to `v22`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R69) [[2]](diffhunk://#diff-45aa1957fcac0cb1334af61a7eccea1b9940dd5052ce03d796788ec0750cef9cL69-R69)

### Dependency Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31): Upgraded `firebase-frameworks` from version `^0.10.6` to `^0.11.6`.