### PR TITLE
feat: install Firebase CLI and update deployment commands in workflow

### DIFF
--- a/.github/workflows/firebase-hosting-master.yml
+++ b/.github/workflows/firebase-hosting-master.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Install dependencies
         run: npm ci && npm run build
 
+      - name: Install Firebase CLI (v13.35.1)
+        run: npm install -g firebase-tools@13.35.1
+
       - name: Deploy to Live
         run: |
-          npx firebase-tools experiments:enable webframeworks
-          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud.json && npx firebase-tools deploy --only functions,hosting -m "Deploying ${{ github.sha }}" --force
+          firebase experiments:enable webframeworks
+          export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud.json
+          npx firebase-tools deploy --only functions,hosting -m "Deploying ${{ github.sha }}" --force


### PR DESCRIPTION
This pull request updates the Firebase deployment workflow to ensure compatibility with the latest Firebase CLI version and improve clarity in deployment commands.

Updates to Firebase deployment workflow:

* [`.github/workflows/firebase-hosting-master.yml`](diffhunk://#diff-d7d51bb2918444fdbe6c21b13561e5d391653cf451ee41ff34335e3396f691f1R28-R35): Added a step to explicitly install Firebase CLI version 13.35.1 before deployment.
* [`.github/workflows/firebase-hosting-master.yml`](diffhunk://#diff-d7d51bb2918444fdbe6c21b13561e5d391653cf451ee41ff34335e3396f691f1R28-R35): Replaced `npx firebase-tools experiments:enable webframeworks` with `firebase experiments:enable webframeworks` for better readability and alignment with the installed CLI.